### PR TITLE
Fix ports cache and optimize pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Cache ports
         uses: actions/cache@v3
         with:
-          path: ./ports
+          path: ports
           key: cross-compiled-${{ hashFiles('**/.ports_versions') }}
       - name: Build gem
         run: |
@@ -100,7 +100,32 @@ jobs:
         env:
           TOXIPROXY_HOST: "localhost"
 
+  compile-native-ports:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+          bundler-cache: true
+
+      - name: Write used versions into file
+        run: bundle exec rake ports:version_file
+
+      - name: Cache ports
+        uses: actions/cache@v3
+        with:
+          path: ports
+          key: native-${{ hashFiles('**/.ports_versions') }}
+
+      - name: Build required libraries
+        run: |
+          bundle exec rake ports
+
   test-linux:
+    needs:
+      - compile-native-ports
     strategy:
       matrix:
         ruby-version: [ 2.4, 2.5, 2.6, 2.7 ]
@@ -120,12 +145,9 @@ jobs:
       - name: Cache ports
         uses: actions/cache@v3
         with:
-          path: ./ports
+          path: ports
           key: native-${{ hashFiles('**/.ports_versions') }}
-
-      - name: Build required libraries
-        run: |
-          bundle exec rake ports
+          fail-on-cache-miss: true
 
       - name: Build gem
         run: |

--- a/tasks/ports/recipe.rb
+++ b/tasks/ports/recipe.rb
@@ -6,10 +6,11 @@ require 'rbconfig'
 module Ports
   class Recipe < MiniPortile
     def cook
-      checkpoint = "ports/#{name}-#{version}-#{host}.installed"
+      checkpoint = "ports/checkpoints/#{name}-#{version}-#{host}.installed"
 
       unless File.exist? checkpoint
         super
+        FileUtils.mkdir_p("ports/checkpoints")
         FileUtils.touch checkpoint
       end
     end


### PR DESCRIPTION
Looks like Github Actions ignores the ".installed" files when it's directly in /ports - wasn't really able to find out why it behaves like this, but moving it to `ports/checkpoints` worked out.