### PR TITLE
Support Ruby 3.1 and 3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.1'
       - name: Install gems
         run: bundle install
       - name: Write used versions into file
@@ -48,6 +48,7 @@ jobs:
           - 2.6
           - 2.7
           - '3.0'
+          - 3.1
     name: Test on Windows
     runs-on: windows-latest
     steps:
@@ -113,7 +114,7 @@ jobs:
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.1
           bundler-cache: true
 
       - name: Write used versions into file
@@ -140,6 +141,7 @@ jobs:
           - 2.6
           - 2.7
           - '3.0'
+          - 3.1
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1'
+          ruby-version: '2.7'
       - name: Install gems
         run: bundle install
       - name: Write used versions into file
@@ -41,6 +41,7 @@ jobs:
     needs:
       - cross-compile
     strategy:
+      fail-fast: false
       matrix:
         ruby-version:
           - 2.4
@@ -49,6 +50,7 @@ jobs:
           - 2.7
           - '3.0'
           - 3.1
+          - 3.2
     name: Test on Windows
     runs-on: windows-latest
     steps:
@@ -67,10 +69,14 @@ jobs:
       - name: Install native gem and restore cross-compiled code from it
         shell: pwsh
         run: |
+          Get-ChildItem
+
           $rubyArchitecture = (ruby -e 'puts RUBY_PLATFORM').Trim()
           $gemVersion = (Get-Content VERSION).Trim()
-          
-          gem install --local --install-dir=./tmp "./tiny_tds-$gemVersion-$rubyArchitecture.gem"
+          $gemToInstall = "./tiny_tds-$gemVersion-$rubyArchitecture.gem"
+
+          Write-Host "Looking to install $gemToInstall"
+          gem install --local --install-dir=./tmp "$gemToInstall"
 
           # Restore precompiled code
           $source = (Resolve-Path ".\tmp\gems\tiny_tds-$gemVersion-$rubyArchitecture\lib\tiny_tds").Path
@@ -114,7 +120,7 @@ jobs:
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.1
+          ruby-version: 3.2
           bundler-cache: true
 
       - name: Write used versions into file
@@ -142,6 +148,7 @@ jobs:
           - 2.7
           - '3.0'
           - 3.1
+          - 3.2
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,37 +7,43 @@ on:
 
 jobs:
   cross-compile:
+    strategy:
+      matrix:
+        platform:
+          - "x64-mingw32"
+          - "x86-mingw32"
+          - "x64-mingw-ucrt"
     name: Cross-compile gem
     runs-on: ubuntu-latest
+    container:
+      image: "ghcr.io/rake-compiler/rake-compiler-dock-image:1.3.0-mri-${{ matrix.platform }}"
     steps:
       - uses: actions/checkout@v3
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '2.7'
+      - run: git config --global --add safe.directory /__w/tiny_tds/tiny_tds # shrug
       - name: Install gems
+        shell: bash
         run: bundle install
       - name: Write used versions into file
-        run: |
-          bundle exec rake ports:version_file
+        shell: bash
+        run: bundle exec rake ports:version_file[${{ matrix.platform }}]
       - name: Cache ports
         uses: actions/cache@v3
         with:
           path: ports
           key: cross-compiled-${{ hashFiles('**/.ports_versions') }}
       - name: Build gem
-        run: |
-          bundle exec rake gem
-          bundle exec rake gem:native
+        shell: bash
+        run: bundle exec rake gem:for_platform[${{ matrix.platform }}]
       - name: Move gems into separate directory before persisting
         run: |
-          mkdir -p artifacts/gems
-          mv pkg/*.gem artifacts/gems
+          mkdir -p artifacts/gem
+          mv pkg/*.gem artifacts/gem
       - uses: actions/upload-artifact@v3
         with:
-          name: gems
-          path: artifacts/gems
+          name: gem-${{ matrix.platform }}
+          path: artifacts/gem
 
-  test-windows:
+  test-windows-mingw:
     needs:
       - cross-compile
     strategy:
@@ -49,9 +55,8 @@ jobs:
           - 2.6
           - 2.7
           - '3.0'
-          - 3.1
-          - 3.2
-    name: Test on Windows
+
+    name: Test on Windows (MingW)
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
@@ -64,13 +69,80 @@ jobs:
       - name: Download precompiled gem
         uses: actions/download-artifact@v3
         with:
-          name: gems
+          name: gem-x64-mingw32
 
       - name: Install native gem and restore cross-compiled code from it
         shell: pwsh
         run: |
-          Get-ChildItem
+          $rubyArchitecture = (ruby -e 'puts RUBY_PLATFORM').Trim()
+          $gemVersion = (Get-Content VERSION).Trim()
+          $gemToInstall = "./tiny_tds-$gemVersion-$rubyArchitecture.gem"
 
+          Write-Host "Looking to install $gemToInstall"
+          gem install --local --install-dir=./tmp "$gemToInstall"
+
+          # Restore precompiled code
+          $source = (Resolve-Path ".\tmp\gems\tiny_tds-$gemVersion-$rubyArchitecture\lib\tiny_tds").Path
+          $destination = (Resolve-Path ".\lib\tiny_tds").Path
+          Get-ChildItem $source -Recurse -Exclude "*.rb" | Copy-Item -Destination {Join-Path $destination $_.FullName.Substring($source.length)}
+
+          # Restore ports
+          Copy-Item -Path ".\tmp\gems\tiny_tds-$gemVersion-$rubyArchitecture\ports" -Destination "." -Recurse
+
+      - name: Setup MSSQL
+        uses: potatoqualitee/mssqlsuite@v1.7
+        with:
+          install: sqlengine, sqlclient
+          version: 2017
+          sa-password: c0MplicatedP@ssword
+          show-log: true
+
+      - name: Setup MSSQL database
+        shell: pwsh
+        run: |
+          & sqlcmd -S localhost -U sa -P "c0MplicatedP@ssword" -Q "CREATE DATABASE [tinytdstest];"
+          & sqlcmd -S localhost -U sa -P "c0MplicatedP@ssword" -Q "CREATE LOGIN [tinytds] WITH PASSWORD = '', CHECK_POLICY = OFF, DEFAULT_DATABASE = [tinytdstest];"
+          & sqlcmd -S localhost -U sa -P "c0MplicatedP@ssword" -Q "USE [tinytdstest]; CREATE USER [tinytds] FOR LOGIN [tinytds]; EXEC sp_addrolemember N'db_owner', N'tinytds';"
+
+      - name: Install toxiproxy-server
+        shell: pwsh
+        run: |
+          choco install toxiproxy-server --version=2.5.0 -y
+          Start-Process toxiproxy-server
+
+      - name: Test gem
+        shell: pwsh
+        run: bundle exec rake test
+        env:
+          TOXIPROXY_HOST: "localhost"
+
+  test-windows-ucrt:
+    needs:
+      - cross-compile
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version:
+          - 3.1
+          - 3.2
+    name: Test on Windows (UCRT)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
+
+      - name: Download precompiled gem
+        uses: actions/download-artifact@v3
+        with:
+          name: gem-x64-mingw-ucrt
+
+      - name: Install native gem and restore cross-compiled code from it
+        shell: pwsh
+        run: |
           $rubyArchitecture = (ruby -e 'puts RUBY_PLATFORM').Trim()
           $gemVersion = (Get-Content VERSION).Trim()
           $gemToInstall = "./tiny_tds-$gemVersion-$rubyArchitecture.gem"

--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ require_relative './ext/tiny_tds/extconsts'
 
 SPEC = Gem::Specification.load(File.expand_path('../tiny_tds.gemspec', __FILE__))
 
-ruby_cc_ucrt_versions = "3.1.0".freeze
+ruby_cc_ucrt_versions = "3.2.0:3.1.0".freeze
 ruby_cc_mingw32_versions = "3.0.0:2.7.0:2.6.0:2.5.0:2.4.0".freeze
 
 GEM_PLATFORM_HOSTS = {
@@ -15,13 +15,13 @@ GEM_PLATFORM_HOSTS = {
     host: 'x86_64-w64-mingw32',
     ruby_versions: ruby_cc_mingw32_versions
   },
-  'x64-mingw-ucrt' => {
-    host: 'mingw-w64-ucrt-x86_64',
-    ruby_versions: ruby_cc_ucrt_versions
-  },
   'x86-mingw32' => {
     host: 'i686-w64-mingw32',
     ruby_versions: ruby_cc_mingw32_versions
+  },
+  'x64-mingw-ucrt' => {
+    host: 'x86_64-w64-mingw32',
+    ruby_versions: ruby_cc_ucrt_versions
   },
 }
 
@@ -46,15 +46,13 @@ Rake::ExtensionTask.new('tiny_tds', SPEC) do |ext|
     # The fat binary gem doesn't depend on the freetds package, since it bundles the library.
     spec.metadata.delete('msys2_mingw_dependencies')
 
-    platform_host_map = GEM_PLATFORM_HOSTS
     gemplat = spec.platform.to_s
-    host = platform_host_map[gemplat]
 
     # We don't need the sources in a fat binary gem
     spec.files = spec.files.reject { |f| f =~ %r{^ports\/archives/} }
 
     # Make sure to include the ports binaries and libraries
-    spec.files += FileList["ports/#{host}/**/**/{bin,lib}/*"].exclude do |f|
+    spec.files += FileList["ports/#{gemplat}/**/**/{bin,lib}/*"].exclude do |f|
       File.directory? f
     end
 

--- a/Rakefile
+++ b/Rakefile
@@ -6,20 +6,33 @@ require 'rake/extensiontask'
 require_relative './ext/tiny_tds/extconsts'
 
 SPEC = Gem::Specification.load(File.expand_path('../tiny_tds.gemspec', __FILE__))
+
+ruby_cc_ucrt_versions = "3.1.0".freeze
+ruby_cc_mingw32_versions = "3.0.0:2.7.0:2.6.0:2.5.0:2.4.0".freeze
+
 GEM_PLATFORM_HOSTS = {
-  'x86-mingw32' => 'i686-w64-mingw32',
-  'x64-mingw32' => 'x86_64-w64-mingw32'
+  'x64-mingw32' => {
+    host: 'x86_64-w64-mingw32',
+    ruby_versions: ruby_cc_mingw32_versions
+  },
+  'x64-mingw-ucrt' => {
+    host: 'mingw-w64-ucrt-x86_64',
+    ruby_versions: ruby_cc_ucrt_versions
+  },
+  'x86-mingw32' => {
+    host: 'i686-w64-mingw32',
+    ruby_versions: ruby_cc_mingw32_versions
+  },
 }
-RUBY_CC_VERSION="3.0.0:2.7.0:2.6.0:2.5.0:2.4.0".freeze
 
 # Add our project specific files to clean for a rebuild
 CLEAN.include FileList["{ext,lib}/**/*.{so,#{RbConfig::CONFIG['DLEXT']},o}"],
-  FileList["exe/*"]
+              FileList["exe/*"]
 
 # Clobber all our temp files and ports files including .install files
 # and archives
 CLOBBER.include FileList["tmp/**/*"],
-  FileList["ports/**/*"].exclude(%r{^ports/archives})
+                FileList["ports/**/*"].exclude(%r{^ports/archives})
 
 Dir['tasks/*.rake'].sort.each { |f| load f }
 

--- a/ext/tiny_tds/extconf.rb
+++ b/ext/tiny_tds/extconf.rb
@@ -21,9 +21,11 @@ end
 do_help if arg_config('--help')
 
 # Make sure to check the ports path for the configured host
-host = RbConfig::CONFIG['host']
+architecture = RbConfig::CONFIG['arch']
+architecture = "x86-mingw32" if architecture == "i386-mingw32"
+
 project_dir = File.expand_path("../../..", __FILE__)
-freetds_ports_dir = File.join(project_dir, 'ports', host, 'freetds', FREETDS_VERSION)
+freetds_ports_dir = File.join(project_dir, 'ports', architecture, 'freetds', FREETDS_VERSION)
 freetds_ports_dir = File.expand_path(freetds_ports_dir)
 
 # Add all the special path searching from the original tiny_tds build

--- a/tasks/native_gem.rake
+++ b/tasks/native_gem.rake
@@ -11,3 +11,13 @@ task 'gem:native' => ['ports:cross'] do
     RakeCompilerDock.sh "bundle --local && RUBY_CC_VERSION=#{meta[:ruby_versions]} rake native:#{plat} gem", platform: plat
   end
 end
+
+# assumes you are in a container provided by Rake compiler
+# if not, use the task above
+task 'gem:for_platform', [:gem_platform] do |_task, args|
+  args.with_defaults(gem_platform: RUBY_PLATFORM)
+
+  sh "bundle install"
+  Rake::Task["ports:compile"].invoke(GEM_PLATFORM_HOSTS[args.gem_platform][:host], args.gem_platform)
+  sh "RUBY_CC_VERSION=#{GEM_PLATFORM_HOSTS[args.gem_platform][:ruby_versions]} rake native:#{args.gem_platform} gem"
+end

--- a/tasks/native_gem.rake
+++ b/tasks/native_gem.rake
@@ -5,9 +5,9 @@ task 'gem:native' => ['ports:cross'] do
   require 'rake_compiler_dock'
 
   # make sure to install our bundle
-  sh "bundle package --all"   # Avoid repeated downloads of gems by using gem files from the host.
+  sh "bundle package --all" # Avoid repeated downloads of gems by using gem files from the host.
 
-  GEM_PLATFORM_HOSTS.keys.each do |plat|
-    RakeCompilerDock.sh "bundle --local && RUBY_CC_VERSION=#{RUBY_CC_VERSION} rake native:#{plat} gem", platform: plat
+  GEM_PLATFORM_HOSTS.each do |plat, meta|
+    RakeCompilerDock.sh "bundle --local && RUBY_CC_VERSION=#{meta[:ruby_versions]} rake native:#{plat} gem", platform: plat
   end
 end

--- a/tasks/ports.rake
+++ b/tasks/ports.rake
@@ -90,6 +90,8 @@ namespace :ports do
       ports_version[library] = library_recipe.version
     end
 
+    ports_version[:platforms] = GEM_PLATFORM_HOSTS.keys
+
     File.open(".ports_versions", "w") do |f|
       f.write ports_version
     end

--- a/tasks/ports.rake
+++ b/tasks/ports.rake
@@ -17,31 +17,34 @@ namespace :ports do
   CLEAN.include "ports/*mingw*"
   CLEAN.include "ports/*.installed"
 
-  task :openssl, [:host] do |task, args|
-    args.with_defaults(host: RbConfig::CONFIG['host'])
+  task :openssl, [:host, :gem_platform] do |_task, args|
+    args.with_defaults(host: RbConfig::CONFIG['host'], gem_platform: RUBY_PLATFORM)
 
     libraries_to_compile[:openssl].files = [OPENSSL_SOURCE_URI]
     libraries_to_compile[:openssl].host = args.host
+    libraries_to_compile[:openssl].gem_platform = args.gem_platform
     libraries_to_compile[:openssl].cook
     libraries_to_compile[:openssl].activate
   end
 
-  task :libiconv, [:host] do |task, args|
-    args.with_defaults(host: RbConfig::CONFIG['host'])
+  task :libiconv, [:host, :gem_platform] do |_task, args|
+    args.with_defaults(host: RbConfig::CONFIG['host'], gem_platform: RUBY_PLATFORM)
 
     libraries_to_compile[:libiconv].files = [ICONV_SOURCE_URI]
     libraries_to_compile[:libiconv].host = args.host
+    libraries_to_compile[:libiconv].gem_platform = args.gem_platform
     libraries_to_compile[:libiconv].cook
     libraries_to_compile[:libiconv].activate
   end
 
-  task :freetds, [:host] do |task, args|
-    args.with_defaults(host: RbConfig::CONFIG['host'])
+  task :freetds, [:host, :gem_platform] do |_task, args|
+    args.with_defaults(host: RbConfig::CONFIG['host'], gem_platform: RUBY_PLATFORM)
 
     libraries_to_compile[:freetds].files = [FREETDS_SOURCE_URI]
     libraries_to_compile[:freetds].host = args.host
+    libraries_to_compile[:freetds].gem_platform = args.gem_platform
 
-    if libraries_to_compile[:openssl]
+    if libraries_to_compile[:openssl] && args.gem_platform != 'x64-mingw-ucrt'
       # freetds doesn't have an option that will provide an rpath
       # so we do it manually
       ENV['OPENSSL_CFLAGS'] = "-Wl,-rpath -Wl,#{libraries_to_compile[:openssl].path}/lib"
@@ -59,13 +62,13 @@ namespace :ports do
     libraries_to_compile[:freetds].activate
   end
 
-  task :compile, [:host] do |task, args|
-    args.with_defaults(host: RbConfig::CONFIG['host'])
+  task :compile, [:host, :gem_platform] do |task, args|
+    args.with_defaults(host: RbConfig::CONFIG['host'], gem_platform: RUBY_PLATFORM)
 
-    puts "Compiling ports for #{args.host}..."
+    puts "Compiling ports for #{args.host} (Ruby platform #{args.gem_platform}) ..."
 
     libraries_to_compile.keys.each do |lib|
-      Rake::Task["ports:#{lib}"].invoke(args.host)
+      Rake::Task["ports:#{lib}"].invoke(args.host, args.gem_platform)
     end
   end
 
@@ -77,7 +80,7 @@ namespace :ports do
     GEM_PLATFORM_HOSTS.each do |gem_platform, meta|
       # make sure to install our bundle
       build = ['bundle']
-      build << "RUBY_CC_VERSION=#{meta[:ruby_versions]} rake ports:compile[#{meta[:host]}] MAKE='make -j`nproc`'"
+      build << "RUBY_CC_VERSION=#{meta[:ruby_versions]} rake ports:compile[#{meta[:host]},#{gem_platform}] MAKE='make -j`nproc`'"
       RakeCompilerDock.sh build.join(' && '), platform: gem_platform
     end
   end

--- a/tasks/ports.rake
+++ b/tasks/ports.rake
@@ -14,7 +14,7 @@ namespace :ports do
   }
 
   directory "ports"
-  CLEAN.include "ports/*mingw32*"
+  CLEAN.include "ports/*mingw*"
   CLEAN.include "ports/*.installed"
 
   task :openssl, [:host] do |task, args|
@@ -74,10 +74,10 @@ namespace :ports do
     require 'rake_compiler_dock'
 
     # build the ports for all our cross compile hosts
-    GEM_PLATFORM_HOSTS.each do |gem_platform, host|
+    GEM_PLATFORM_HOSTS.each do |gem_platform, meta|
       # make sure to install our bundle
       build = ['bundle']
-      build << "RUBY_CC_VERSION=#{RUBY_CC_VERSION} rake ports:compile[#{host}] MAKE='make -j`nproc`'"
+      build << "RUBY_CC_VERSION=#{meta[:ruby_versions]} rake ports:compile[#{meta[:host]}] MAKE='make -j`nproc`'"
       RakeCompilerDock.sh build.join(' && '), platform: gem_platform
     end
   end

--- a/tasks/ports.rake
+++ b/tasks/ports.rake
@@ -86,14 +86,16 @@ namespace :ports do
   end
 
   desc "Notes the actual versions for the compiled ports into a file"
-  task "version_file" do
+  task "version_file", [:gem_platform] do |_task, args|
+    args.with_defaults(gem_platform: RUBY_PLATFORM)
+
     ports_version = {}
 
     libraries_to_compile.each do |library, library_recipe|
       ports_version[library] = library_recipe.version
     end
 
-    ports_version[:platforms] = GEM_PLATFORM_HOSTS.keys
+    ports_version[:platform] = args.gem_platform
 
     File.open(".ports_versions", "w") do |f|
       f.write ports_version

--- a/tasks/ports/recipe.rb
+++ b/tasks/ports/recipe.rb
@@ -5,8 +5,10 @@ require 'rbconfig'
 
 module Ports
   class Recipe < MiniPortile
+    attr_writer :gem_platform
+
     def cook
-      checkpoint = "ports/checkpoints/#{name}-#{version}-#{host}.installed"
+      checkpoint = "ports/checkpoints/#{name}-#{version}-#{gem_platform}.installed"
 
       unless File.exist? checkpoint
         super
@@ -16,6 +18,16 @@ module Ports
     end
 
     private
+
+    attr_reader :gem_platform
+
+    def port_path
+      "#{@target}/#{gem_platform}/#{@name}/#{@version}"
+    end
+
+    def tmp_path
+      "tmp/#{gem_platform}/ports/#{@name}/#{@version}"
+    end
 
     def configure_defaults
       [


### PR DESCRIPTION
... many changes in this PR. It was also not intended to tackle Ruby 3.1 and 3.2 in the same branch, as one could guess from the branch name :sweat_smile: .

The first major, non-visible issue was an error message when compiling OpenSSL on UCRT that went something like `undefined reference to sscanf`. I first skipped the OpenSSL in favor of linking FreeTDS against GnuTLS, but then realised that this likely won't work. The main trouble was that the `gcc` version for `msvcrt` and `ucrt` are both named `x86_64-w64-mingw32`. Since `mini_portile` uses this target platform for the paths to build a port, it re-used the configured `msvcrt` installation for `ucrt`, which, of course, does not work. So all those changes in `ports.rake` where I pass the gem platform in addition to the host platform and the overwrites in `recipe` are to distinguish builds between `msvcrt` and `ucrt`  based on the Ruby platform, not target platform.

Once the UCRT build worked on CI, I had another fun issue: when trying to install the compiled gems for Windows to get the compiled libraries, it raised `Unable to find spec for #<Gem::NameTuple tiny_tds, 2.1.5, x64-unknown>`, but only for 2.7 and below. Turned out that when installing a gem locally, Rubygems parsed all gem specifications for any file named `*.gem` in the current directory. And since older versions of Rubygems don't know `ucrt`, it raised `x64-unknown`. I found it out by essentially running `byebug /my/ruby/installation/bin/gem install tiny_tds`, opening the source code of Rubygems to find out where it got the specs from and setting a breakpoint using an absolute path again. This was solved by the parallel build from `328dc1b7`.