### PR TITLE
Support MSSQL 2019 and 2022

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
         mssql-version:
           - 2017
           - 2019
+          - 2022
         ruby-version:
           - 2.4
           - 2.5
@@ -131,6 +132,7 @@ jobs:
         mssql-version:
           - 2017
           - 2019
+          - 2022
         ruby-version:
           - 3.1
           - 3.2
@@ -228,6 +230,7 @@ jobs:
         mssql-version:
           - 2017
           - 2019
+          - 2022
         ruby-version:
           - 2.4
           - 2.5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        mssql-version:
+          - 2017
+          - 2019
         ruby-version:
           - 2.4
           - 2.5
@@ -93,7 +96,7 @@ jobs:
         uses: potatoqualitee/mssqlsuite@v1.7
         with:
           install: sqlengine, sqlclient
-          version: 2017
+          version: ${{ matrix.mssql-version }}
           sa-password: c0MplicatedP@ssword
           show-log: true
 
@@ -122,6 +125,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        mssql-version:
+          - 2017
+          - 2019
         ruby-version:
           - 3.1
           - 3.2
@@ -162,7 +168,7 @@ jobs:
         uses: potatoqualitee/mssqlsuite@v1.7
         with:
           install: sqlengine, sqlclient
-          version: 2017
+          version: ${{ matrix.mssql-version }}
           sa-password: c0MplicatedP@ssword
           show-log: true
 
@@ -213,6 +219,9 @@ jobs:
       - compile-native-ports
     strategy:
       matrix:
+        mssql-version:
+          - 2017
+          - 2019
         ruby-version:
           - 2.4
           - 2.5
@@ -249,7 +258,7 @@ jobs:
         uses: potatoqualitee/mssqlsuite@v1.7
         with:
           install: sqlengine, sqlclient
-          version: 2017
+          version: ${{ matrix.mssql-version }}
           sa-password: "c0MplicatedP@ssword"
           show-log: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
         with:
           path: ports
           key: cross-compiled-${{ hashFiles('**/.ports_versions') }}
+          restore-keys: |
+            cross-compiled-${{ hashFiles('**/.ports_versions') }}
+            cross-compiled-
       - name: Build gem
         shell: bash
         run: bundle exec rake gem:for_platform[${{ matrix.platform }}]
@@ -209,6 +212,9 @@ jobs:
         with:
           path: ports
           key: native-${{ hashFiles('**/.ports_versions') }}
+          restore-keys: |
+            native-${{ hashFiles('* */.ports_versions') }}
+            native-
 
       - name: Build required libraries
         run: |


### PR DESCRIPTION
support .. well, just run the CI against it and get happy because no changes are required to get the tests green.

but I snucked in a small improvement for restoring the ports cache. :)