### PR TITLE
Update precompiled OpenSSL to v1.1.1t

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,10 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ports
-          key: cross-compiled-${{ hashFiles('**/.ports_versions') }}
+          key: cross-compiled-v2-${{ hashFiles('**/.ports_versions') }}
           restore-keys: |
             cross-compiled-${{ hashFiles('**/.ports_versions') }}
-            cross-compiled-
+            cross-compiled-v2-
       - name: Build gem
         shell: bash
         run: bundle exec rake gem:for_platform[${{ matrix.platform }}]
@@ -213,10 +213,10 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ports
-          key: native-${{ hashFiles('**/.ports_versions') }}
+          key: native-v2-${{ hashFiles('**/.ports_versions') }}
           restore-keys: |
             native-${{ hashFiles('* */.ports_versions') }}
-            native-
+            native-v2-
 
       - name: Build required libraries
         run: |
@@ -256,7 +256,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ports
-          key: native-${{ hashFiles('**/.ports_versions') }}
+          key: native-v2-${{ hashFiles('**/.ports_versions') }}
           fail-on-cache-miss: true
 
       - name: Build gem

--- a/ext/tiny_tds/extconsts.rb
+++ b/ext/tiny_tds/extconsts.rb
@@ -2,7 +2,7 @@
 ICONV_VERSION = ENV['TINYTDS_ICONV_VERSION'] || "1.15"
 ICONV_SOURCE_URI = "http://ftp.gnu.org/pub/gnu/libiconv/libiconv-#{ICONV_VERSION}.tar.gz"
 
-OPENSSL_VERSION = ENV['TINYTDS_OPENSSL_VERSION'] || '1.1.1d'
+OPENSSL_VERSION = ENV['TINYTDS_OPENSSL_VERSION'] || '1.1.1t'
 OPENSSL_SOURCE_URI = "https://www.openssl.org/source/openssl-#{OPENSSL_VERSION}.tar.gz"
 
 FREETDS_VERSION = ENV['TINYTDS_FREETDS_VERSION'] || "1.1.24"


### PR DESCRIPTION
There are multiple security vulnerabilities in the versions between 1.1.1d and 1.1.1t. I'm not sure if any of those affect our project, but it's still good to ship a secure version of this program.